### PR TITLE
I've fixed a TypeError in the plotting script.

### DIFF
--- a/plot.js
+++ b/plot.js
@@ -38,7 +38,7 @@ function drawOrdination(labels, coords, method, metadata) {
         type: 'scatter',
         marker: {
           size: 8,
-          color: Plotly.d3.scale.category10().range()[groupSet.indexOf(group)]
+          color: Plotly.colors.qualitative.Plotly[groupSet.indexOf(group)]
         }
       };
     });


### PR DESCRIPTION
The error "Cannot read properties of undefined (reading 'scale')" was caused by an incorrect attempt to access the d3 scale from the Plotly object. I resolved this by replacing the deprecated `Plotly.d3.scale.category10().range()` with the appropriate color scale `Plotly.colors.qualitative.Plotly` for the version of Plotly.js you're using (2.12.1).