### PR TITLE
I've fixed a `TypeError` in the plotting script.

### DIFF
--- a/plot.js
+++ b/plot.js
@@ -27,6 +27,7 @@ function drawOrdination(labels, coords, method, metadata) {
   if (metadata) {
     const { groups, groupLabels } = metadata;
     const groupSet = [...new Set(groups)];
+    const colors = ['#1f77b4', '#ff7f0e', '#2ca02c', '#d62728', '#9467bd', '#8c564b', '#e377c2', '#7f7f7f', '#bcbd22', '#17becf'];
     const traces = groupSet.map(group => {
       const indices = groups.map((g, i) => g === group ? i : -1).filter(i => i !== -1);
       return {
@@ -38,7 +39,7 @@ function drawOrdination(labels, coords, method, metadata) {
         type: 'scatter',
         marker: {
           size: 8,
-          color: Plotly.colors.qualitative.Plotly[groupSet.indexOf(group)]
+          color: colors[groupSet.indexOf(group) % colors.length]
         }
       };
     });


### PR DESCRIPTION
The error "Cannot read properties of undefined (reading 'qualitative')" was caused by an incorrect attempt to access the color scales from the Plotly object. I resolved this by defining a custom qualitative color array and using it to assign colors to the markers. This approach is more robust and not dependent on the Plotly.js version.