### PR TITLE
Fix GitHub Actions: use correct rust-toolchain action

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Rust
-        uses: dtolnay/rust-action@stable
+        uses: dtolnay/rust-toolchain@stable
         with:
           targets: wasm32-unknown-unknown
 


### PR DESCRIPTION
Changed dtolnay/rust-action to dtolnay/rust-toolchain

https://claude.ai/code/session_01Pe6XQxvAppCK74x4wVf8M7